### PR TITLE
[TASK] Add Ruby 2.1.0 to .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: bundler
 
 rvm:
   - 2.0.0
+  - 2.1.0
 
 script:
   - bundle exec rake --trace test

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@
 
 task default: :test
 
-task test: [:travis_lint, :rubocop, :reek, :scss_lint]
+task test: [:rubocop, :reek, :scss_lint]
 
 task :travis_lint do
   sh 'travis-lint'


### PR DESCRIPTION
Also drop travis-lint form the default task as the current version of travis-lint
does not know that Travis supports Ruby 2.1.0.
