### PR TITLE
[TASK] Drop travis-lint

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,10 +6,6 @@ task default: :test
 
 task test: [:rubocop, :reek, :scss_lint]
 
-task :travis_lint do
-  sh 'travis-lint'
-end
-
 task :rubocop do
   sh 'rubocop Gemfile Rakefile yamlcss.gemspec lib/'
 end

--- a/yamlcss.gemspec
+++ b/yamlcss.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'aruba'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'travis-lint'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'reek'
   s.add_development_dependency 'scss-lint'


### PR DESCRIPTION
travis-lint often is outdated and does not allow new entries like
recently added RVM version. So using it is not really helpful.