### PR TITLE
[TASK] Drop support for Ruby 1.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_install:
   - git submodule update --init --recursive
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2

--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,7 @@ This gem is brought to you by the [Brain Gourmets](http://www.braingourmets.com/
 
 ### Requirements
 
-* Ruby >= 1.9.3
+* Ruby >= 2.0.0
 
 * Sass 3.2+ (if you want to use YAML Sass files)
 

--- a/yamlcss.gemspec
+++ b/yamlcss.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files                 = ['lib/yamlcss.rb']
   s.homepage              = 'https://github.com/braingourmets/yamlcss-gem'
   s.license               = 'CC-BY 2.0'
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
   s.post_install_message  = 'Thank you for installing YAML!'
 
   s.add_dependency 'sass'


### PR DESCRIPTION
Ruby 1.9.3 was end-of-lifed on 2015-02-23.