### PR TITLE
[TASK] Drop the Gemnasium badge from the README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,11 +3,10 @@
 [![Build Status](https://travis-ci.org/braingourmets/yamlcss-gem.svg?branch=master)](https://travis-ci.org/braingourmets/yamlcss-gem)
 [![Code Climate](https://codeclimate.com/github/braingourmets/yamlcss-gem.svg)](https://codeclimate.com/github/braingourmets/yamlcss-gem)
 [![Gem Version](https://badge.fury.io/rb/yamlcss.svg)](http://badge.fury.io/rb/yamlcss)
-[![Dependency Status](https://gemnasium.com/braingourmets/yamlcss-gem.svg)](https://gemnasium.com/braingourmets/yamlcss-gem)
 
 YAML (*Yet Another Multicolumn Layout*) is a modular CSS framework for truly
-flexible, accessible and responsive websites. YAML is focussed on device
-independent screen design and provides bullet-proof modules for flexible
+flexible, accessible and responsive websites. YAML is focused on
+device-independent screen design and provides bullet-proof modules for flexible
 layouts. This is a perfect starting point and the key to truly responsive
 design.
 


### PR DESCRIPTION
The service now is defunct.

Also fix smaller typos in the README.

[ci skip]